### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ updates:
       - "MikuroXina"
     target-branch: main
     commit-message:
-      prefix: chore(ci)
+      prefix: ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "MikuroXina"
+    target-branch: main
+    commit-message:
+      prefix: chore(npm)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "MikuroXina"
+    target-branch: main
+    commit-message:
+      prefix: chore(ci)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - "shun-shobon"
     target-branch: main
     commit-message:
-      prefix: chore(npm)
+      prefix: build(deps)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "monthly"
     reviewers:
       - "MikuroXina"
+      - "shun-shobon"
     target-branch: main
     commit-message:
       prefix: chore(npm)


### PR DESCRIPTION
dependabot の設定ファイルを追加し [Dependabot version updates](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates) を有効化します。

監視対象に npm と GitHub Actions を指定し、月始めにPRを作成、自動指定のレビュワーを @MikuroXina に設定しています。

変更すべき箇所はRCで指摘ください