### PR TITLE
ci: Update `actions/setup-node` version 2 to 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: lts
           cache: yarn
       - run: yarn install --frozen-lockfile
 
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: lts
           cache: yarn
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts
+          node-version: lts/*
           cache: yarn
       - run: yarn install --frozen-lockfile
 
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts
+          node-version: lts/*
           cache: yarn
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,10 @@ jobs:
           - stylelint
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-
+          cache: yarn
       - run: yarn install --frozen-lockfile
 
       - name: Run ${{ matrix.lint }}
@@ -36,18 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache.outputs.dir }}
-            ./.next/cache
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-
+          cache: yarn
       - run: yarn install --frozen-lockfile
 
       - name: Run build


### PR DESCRIPTION
GitHub Actions中で使用されている`actions/setup-node`をv2からv3へアップグレードしました。
v3にはキャッシュ機能が備わってるため、それを使用するように変更しました。