### PR TITLE
fix: ダークテーマ検出の挙動を改善

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -46,7 +46,7 @@ export const theme = extendTheme({
     },
   },
   config: {
-    initialColorMode: "light",
-    useSystemColorMode: true,
+    initialColorMode: "system",
+    useSystemColorMode: false,
   },
 });


### PR DESCRIPTION
Chakra のドキュメントによれば

> if `useSystemColorMode=true` we will always try to match the users `system`-color and fallback to `initialColorMode`. With this behavior, the colorMode toggle won't have any effect.
> if `initialColorMode='system'` we will as well always try to match the users `system`-color and fallback to `light`. After the user has toggled the value, this value will be used.
> _[Color Mode \- Chakra UI](https://chakra-ui.com/docs/styled-system/color-mode#updating-the-theme-config)_

- いまの設定は前者だけど、toggle は機能しないはずらしい
  ドキュメントが間違ってるのか実装が間違ってるのかは知らないけど
- 期待される挙動は後者では

ということで改善する

---

私の個人開発のやつだとこういう UI を用意してるけど、ここまではいらないよね

![image](https://user-images.githubusercontent.com/33474143/200037799-3506221e-3bde-4a02-a3b0-3bdbea263b87.png)
